### PR TITLE
Allow custom app-starting commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ exports.getRequest = (config) => {
   if (process.env.E2E_TESTS) {
     return supertest(utils.getUrl(config));
   }
-  return supertest(proxyquire(path.join(config.cwd, 'app'), {}));
+  return supertest(proxyquire(path.join(config.cwd, config.cmd || 'app'), {}));
 };
 
 exports.run = (cmd, cwd) => {


### PR DESCRIPTION
This is necessary for non-`app.js` files to be started (e.g. `worker.js`).