### PR TITLE
fix: update to latest eslint toolchain, get lint passing

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,8 +8,9 @@ plugins:
   - prettier
 rules:
   prettier/prettier: error
-  block-scoped-var: error
+  block-scoped-var: warn
   eqeqeq: error
   no-warning-comments: warn
-  node/no-unsupported-features: off
-  node/no-missing-require: off
+  no-unsafe-finally: warn
+  node/no-deprecated-api: warn
+

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,4 +13,4 @@ rules:
   no-warning-comments: warn
   no-unsafe-finally: warn
   node/no-deprecated-api: warn
-
+  node/no-missing-require: warn

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "babel-cli": "6.26.0",
     "babel-preset-env": "1.6.1",
     "codecov": "^3.1.0",
-    "eslint": "^4.18.2",
-    "eslint-config-prettier": "^2.10.0",
-    "eslint-plugin-node": "8.0.0",
+    "eslint": "^5.8.0",
+    "eslint-config-prettier": "^3.0.0",
+    "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "prettier": "^1.11.0"
   }


### PR DESCRIPTION
It ain't perfect, but it gets things working again.